### PR TITLE
Fix submodule path by dropping .sty extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you want to use it too, just add it as a Git [submodule][submodule]
 to your repo:
 
 ```bash
-git submodule add https://github.com/yegor256/lecture-notes.sty
+git submodule add https://github.com/yegor256/lecture-notes
 ```
 
 They, use this package in the `.tex` file:


### PR DESCRIPTION
This changes fixes submodule path,
by removing `.sty` extension.
It makes the package importable via `\usepackage{lecture-notes/notes}`, as suggested in the `README.md`.

With `.sty` extension one would need to import the package via `\usepackage{lecture-notes.sty/notes}`,
which contradicts the `README.md`.