### PR TITLE
Add `tocbibind` dependency

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -60,6 +60,7 @@ hard tikzpagenodes
 hard titlesec
 hard titling
 hard to-be-determined
+hard tocbibind
 hard totpages
 hard transparent
 hard trimspaces


### PR DESCRIPTION
This pull request adds the `tocbibind` package to `DEPENDS.txt`, fixing an error in repositories that rely on `lecture-notes`, such as [sqm](https://github.com/yegor256/sqm/actions/runs/14518265287/job/40732538119) and [painofoop](https://github.com/yegor256/painofoop/actions/runs/14635596790/job/41065925614). The workflow `latexmk.yml` fails in these repositories due to a missing `tocbibind.sty` file:

```
Latexmk: Missing input file 'tocbibind.sty' (or dependence on it) from following:
  ! LaTeX Error: File `tocbibind.sty' not found.
```